### PR TITLE
Get rid of legacy `es` references

### DIFF
--- a/examples/pretty.js
+++ b/examples/pretty.js
@@ -2,12 +2,13 @@
 var inspect = require('util').inspect
 
 if(!module.parent) {
-  var es = require('..')              //load event-stream
+  var map = require('..')             //load map-stream
+  var es = require('event-stream')    //load event-stream
   es.pipe(                            //pipe joins streams together
     process.openStdin(),              //open stdin
     es.split(),                       //split stream to break on newlines
-    es.map(function (data, callback) {//turn this async function into a stream
-      var j 
+    map(function (data, callback) {   //turn this async function into a stream
+      var j
       try {
         j = JSON.parse(data)          //try to parse input into json
       } catch (err) {
@@ -18,8 +19,8 @@ if(!module.parent) {
     process.stdout                    // pipe it to stdout !
     )
   }
-  
+
 // run this
-// 
-// curl -sS registry.npmjs.org/event-stream | node pretty.js 
+//
+// curl -sS registry.npmjs.org/event-stream | node pretty.js
 //

--- a/readme.markdown
+++ b/readme.markdown
@@ -7,9 +7,9 @@ Refactored out of [event-stream](https://github.com/dominictarr/event-stream)
 Create a through stream from an asyncronous function.  
 
 ``` js
-var es = require('event-stream')
+var map = require('map-stream')
 
-es.map(function (data, callback) {
+map(function (data, callback) {
   //transform data
   // ...
   callback(null, data)

--- a/test/simple-map.asynct.js
+++ b/test/simple-map.asynct.js
@@ -68,31 +68,6 @@ function pauseStream (prob, delay) {
   })
 }
 
-exports ['simple map'] = function (test) {
-
-  var input = u.map(1, 1000, function () {
-    return Math.random() 
-  })
-  var expected = input.map(function (v) {
-    return v * 2
-  })
-
-  var pause = pauseStream(0.1)
-  var fs = from(input)
-  var ts = es.writeArray(function (err, ar) {
-    it(ar).deepEqual(expected)
-    test.done()
-  })
-  var map = es.through(function (data) {
-    this.emit('data', data * 2)
-  }) 
-
-  spec(map).through().validateOnExit()
-  spec(pause).through().validateOnExit()
-
-  fs.pipe(map).pipe(pause).pipe(ts)
-}
-
 exports ['simple map applied to a stream'] = function (test) {
 
   var input = [1,2,3,7,5,3,1,9,0,2,4,6]
@@ -130,7 +105,7 @@ exports['pipe two maps together'] = function (test) {
   function dd (data, cb) {
     cb(null, data * 2)
   }
-  var doubler1 = es.map(dd), doubler2 = es.map(dd)
+  var doubler1 = map(dd), doubler2 = map(dd)
 
   doubler1.pipe(doubler2)
   
@@ -182,7 +157,7 @@ exports ['emit error thrown'] = function (test) {
 
   var err = new Error('INTENSIONAL ERROR')
     , mapper = 
-  es.map(function () {
+  map(function () {
     throw err
   })
 
@@ -199,7 +174,7 @@ exports ['emit error calledback'] = function (test) {
 
   var err = new Error('INTENSIONAL ERROR')
     , mapper = 
-  es.map(function (data, callback) {
+  map(function (data, callback) {
     callback(err)
   })
 


### PR DESCRIPTION
Updated all of the references from `es.map` to just `map` - including in the unit tests.

There was one unit test (`'simple map'`) that wasn't even using `es.map` - it seemed to be testing `es.through` - so I removed it entirely.
