### PR TITLE
Support continueOnError

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,7 @@ var Stream = require('stream').Stream
 //emitting each response as data
 //unless it's an empty callback
 
-module.exports = function (opts, mapper) {
-
-  if (typeof opts === 'function') {
-    mapper = opts;
-    opts = {};
-  }
+module.exports = function (mapper, opts) {
 
   var stream = new Stream()
     , self = this
@@ -30,7 +25,7 @@ module.exports = function (opts, mapper) {
     , inNext = false
 
   this.opts = opts || {};
-  var errorEventName = opts.failures ? 'failure' : 'error';
+  var errorEventName = this.opts.failures ? 'failure' : 'error';
 
   // Items that are not ready to be written yet (because they would come out of
   // order) get stuck in a queue for later.

--- a/readme.markdown
+++ b/readme.markdown
@@ -2,7 +2,7 @@
 
 Refactored out of [event-stream](https://github.com/dominictarr/event-stream)
 
-##map ([options, ]asyncFunction)
+##map (asyncFunction[, options])
 
 Create a through stream from an asyncronous function.  
 

--- a/test/simple-map.asynct.js
+++ b/test/simple-map.asynct.js
@@ -118,9 +118,9 @@ exports ['stream comes back in the correct order'] = function (test) {
 exports ['continues on error event with failures `true`'] = function (test) {
   var input = [1, 2, 3]
 
-  var delayer = map({ failures: true }, function(data, cb){
+  var delayer = map(function(data, cb){
     cb(new Error('Something gone wrong'), data)
-  })
+  }, { failures: true })
 
   readStream(delayer, function (err, output) {
     it(output).deepEqual(input)
@@ -188,9 +188,9 @@ exports ['emit failures with opts.failures === `ture`'] = function (test) {
 
   var err = new Error('INTENSIONAL ERROR')
     , mapper = 
-  map({ failures: true }, function () {
+  map(function () {
     throw err
-  })
+  }, { failures: true })
 
   mapper.on('failure', function (_err) {
     it(_err).equal(err)  


### PR DESCRIPTION
It would be nice, if map can continue after error emitted.
