### PR TITLE
Fix "Maximum call stack size exceeded" warnings when processing lots of

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,10 @@ module.exports = function (mapper) {
     if (writeQueue.hasOwnProperty(nextToWrite)) {
       var dataToWrite = writeQueue[nextToWrite]
       delete writeQueue[nextToWrite]
-      return queueData(dataToWrite, nextToWrite)
+      process.nextTick(function() {
+        queueData(dataToWrite, nextToWrite);
+      })
+      return
     }
 
     outputs ++


### PR DESCRIPTION
items
