### PR TITLE
Accept Promises returned from mapper function

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,9 +81,21 @@ module.exports = function (mapper, opts) {
   // Wrap the mapper function by calling its callback with the order number of
   // the item in the stream.
   function wrappedMapper (input, number, callback) {
-    return mapper.call(null, input, function(err, data){
+    var result = mapper.call(null, input, function(err, data){
       callback(err, data, number)
     })
+
+    // If returned result is a "thenable"
+    if (result && result.then) {
+      result.then(function(data) {
+        callback(null, data, number)
+      }, function(err) {
+        callback(err, null, number)
+      })
+      return;
+    } else {
+      return result
+    }
   }
 
   stream.write = function (data) {

--- a/test/simple-map.asynct.js
+++ b/test/simple-map.asynct.js
@@ -315,4 +315,35 @@ exports ['map applied to a stream with filtering'] = function (test) {
   
 }
 
+exports ['promise map applied to a stream'] = function (test) {
 
+  var input = [1,2,3,7,5,3,1,9,0,2,4,6]
+  //create event stream from
+
+  var doubler = map(function (data) {
+    return {
+      then: function(onFulfilled) {
+        onFulfilled(data * 2)
+      }
+    }
+  })
+
+  spec(doubler).through().validateOnExit()
+
+  //a map is only a middle man, so it is both readable and writable
+
+  it(doubler).has({
+    readable: true,
+    writable: true,
+  })
+
+  readStream(doubler, function (err, output) {
+    it(output).deepEqual(input.map(function (j) {
+      return j * 2
+    }))
+//    process.nextTick(x.validate)
+    test.done()
+  })
+
+  writeArray(input, doubler)
+}


### PR DESCRIPTION
Curious what you think of this idea.

``` javascript
function getJSON(url) {
  return new Promise(function(resolve) {
    http.get(url, function(res) {
      // ...
      res.on('end', function() {
        resolve(JSON.parse(body));
      });
    })
  })
}

var map = require('map-stream');
process.stdin
  .pipe(map(getJSON))
  .pipe(process.stdout);
```

Similar to `mapSync`.
