### PR TITLE
Fixes #11: Add MIT license to package.json and LICENSE file

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2011 Dominic Tarr
 
 Permission is hereby granted, free of charge, 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "map-stream",
   "version": "0.0.4",
+  "license": "MIT",
   "description": "construct pipes of streams of events",
   "homepage": "http://github.com/dominictarr/map-stream",
   "repository": {


### PR DESCRIPTION
Allow the license to be determined programatically by including it in package.json; including standard wording at top of LICENSE file.
