### PR TITLE
Resolving maximum call stack size exceeded issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ module.exports = function (mapper, opts) {
   // Wrap the mapper function by calling its callback with the order number of
   // the item in the stream.
   function wrappedMapper (input, number, callback) {
-    return mapper.call(null, input, function(err, data) {
+    return mapper.call(null, input, function(err, data){
       callback(err, data, number)
     })
   }

--- a/index.js
+++ b/index.js
@@ -53,9 +53,9 @@ module.exports = function (mapper, opts) {
           stream.emit.apply(stream, ['data', dataToWrite])
         }
 
-        lastWritten++
-        nextToWrite++
-        outputs++
+        lastWritten ++
+        nextToWrite ++
+        outputs ++
 
         // If the next value is in the queue, keeping writing from the queue
       } while (writeQueue.hasOwnProperty(nextToWrite))
@@ -75,12 +75,12 @@ module.exports = function (mapper, opts) {
     if(destroyed) return
     inNext = true
 
-    if(!err || opts.failures) {
+    if (!err || opts.failures) {
       queueData(data, number)
     }
 
-    if(err) {
-      stream.emit.apply(stream, [errorEventName, err]);
+    if (err) {
+      stream.emit.apply(stream, [ errorEventName, err ]);
     }
 
     inNext = false;
@@ -89,7 +89,7 @@ module.exports = function (mapper, opts) {
   // Wrap the mapper function by calling its callback with the order number of
   // the item in the stream.
   function wrappedMapper (input, number, callback) {
-    return mapper.call(null, input, function (err, data) {
+    return mapper.call(null, input, function(err, data) {
       callback(err, data, number)
     })
   }
@@ -97,7 +97,7 @@ module.exports = function (mapper, opts) {
   stream.write = function (data) {
     if(ended) throw new Error('map stream is not writable')
     inNext = false
-    inputs++
+    inputs ++
 
     try {
       //catch sync errors and handle them like async errors
@@ -120,8 +120,8 @@ module.exports = function (mapper, opts) {
     stream.writable = false
     if(data !== undefined) {
       return queueData(data, inputs)
-    } else if(inputs == outputs) { //wait for processing 
-      stream.readable = false, stream.emit('end'), stream.destroy()
+    } else if (inputs == outputs) { //wait for processing 
+      stream.readable = false, stream.emit('end'), stream.destroy() 
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -35,35 +35,34 @@ module.exports = function (mapper, opts) {
 
   function queueData(data, number) {
     var nextToWrite = lastWritten + 1
-    var dataWritten = false;
 
-    if (number !== nextToWrite) {
-      // Otherwise queue it for later.
-      writeQueue[number] = data
-    } else {
-      // If the next value is in the queue, write it
-      while ((number === nextToWrite && !dataWritten) || writeQueue.hasOwnProperty(nextToWrite)) {
-        // If it's next, and its not undefined write it
+    if (number === nextToWrite) {
+      do {
         var dataToWrite;
-        if (!dataWritten) {
+
+        // write data contents only for the first iteration
+        if (number === nextToWrite) {
           dataToWrite = data
         } else {
           dataToWrite = writeQueue[nextToWrite]
           delete writeQueue[nextToWrite]
         }
+
+        // If it's next, and its not undefined write it
         if (dataToWrite !== undefined) {
           stream.emit.apply(stream, ['data', dataToWrite])
         }
 
-        // current data is written, mark it to only write additional items in queue
-        dataWritten = true
         lastWritten++
         nextToWrite++
-        number++
         outputs++
-
         
-      }
+        // If the next value is in the queue, keeping writing from the queue
+      } while (writeQueue.hasOwnProperty(nextToWrite))
+
+    } else {
+      // Otherwise queue it for later.
+      writeQueue[number] = data
     }
 
     if (inputs === outputs) {

--- a/index.js
+++ b/index.js
@@ -14,14 +14,14 @@ var Stream = require('stream').Stream
 
 module.exports = function (mapper, opts) {
 
-  var stream = new Stream(),
-    inputs = 0,
-    outputs = 0,
-    ended = false,
-    paused = false,
-    destroyed = false,
-    lastWritten = 0,
-    inNext = false
+  var stream = new Stream()
+    , inputs = 0
+    , outputs = 0
+    , ended = false
+    , paused = false
+    , destroyed = false
+    , lastWritten = 0
+    , inNext = false
 
   opts = opts || {};
   var errorEventName = opts.failures ? 'failure' : 'error';
@@ -33,15 +33,15 @@ module.exports = function (mapper, opts) {
   stream.writable = true
   stream.readable = true
 
-  function queueData(data, number) {
+  function queueData (data, number) {
     var nextToWrite = lastWritten + 1
 
-    if (number === nextToWrite) {
+    if(number === nextToWrite) {
       do {
         var dataToWrite;
 
         // write data contents only for the first iteration
-        if (number === nextToWrite) {
+        if(number === nextToWrite) {
           dataToWrite = data
         } else {
           dataToWrite = writeQueue[nextToWrite]
@@ -49,14 +49,14 @@ module.exports = function (mapper, opts) {
         }
 
         // If it's next, and its not undefined write it
-        if (dataToWrite !== undefined) {
+        if(dataToWrite !== undefined) {
           stream.emit.apply(stream, ['data', dataToWrite])
         }
 
         lastWritten++
         nextToWrite++
         outputs++
-        
+
         // If the next value is in the queue, keeping writing from the queue
       } while (writeQueue.hasOwnProperty(nextToWrite))
 
@@ -65,21 +65,21 @@ module.exports = function (mapper, opts) {
       writeQueue[number] = data
     }
 
-    if (inputs === outputs) {
-      if (paused) paused = false, stream.emit('drain') //written all the incoming events
-      if (ended) end()
+    if(inputs === outputs) {
+      if(paused) paused = false, stream.emit('drain') //written all the incoming events
+      if(ended) end()
     }
   }
 
-  function next(err, data, number) {
-    if (destroyed) return
+  function next (err, data, number) {
+    if(destroyed) return
     inNext = true
 
-    if (!err || opts.failures) {
+    if(!err || opts.failures) {
       queueData(data, number)
     }
 
-    if (err) {
+    if(err) {
       stream.emit.apply(stream, [errorEventName, err]);
     }
 
@@ -88,14 +88,14 @@ module.exports = function (mapper, opts) {
 
   // Wrap the mapper function by calling its callback with the order number of
   // the item in the stream.
-  function wrappedMapper(input, number, callback) {
+  function wrappedMapper (input, number, callback) {
     return mapper.call(null, input, function (err, data) {
       callback(err, data, number)
     })
   }
 
   stream.write = function (data) {
-    if (ended) throw new Error('map stream is not writable')
+    if(ended) throw new Error('map stream is not writable')
     inNext = false
     inputs++
 
@@ -107,26 +107,26 @@ module.exports = function (mapper, opts) {
     } catch (err) {
       //if the callback has been called syncronously, and the error
       //has occured in an listener, throw it again.
-      if (inNext)
+      if(inNext)
         throw err
       next(err)
       return !paused
     }
   }
 
-  function end(data) {
+  function end (data) {
     //if end was called with args, write it, 
     ended = true //write will emit 'end' if ended is true
     stream.writable = false
-    if (data !== undefined) {
+    if(data !== undefined) {
       return queueData(data, inputs)
-    } else if (inputs == outputs) { //wait for processing 
+    } else if(inputs == outputs) { //wait for processing 
       stream.readable = false, stream.emit('end'), stream.destroy()
     }
   }
 
   stream.end = function (data) {
-    if (ended) return
+    if(ended) return
     end(data)
   }
 

--- a/index.js
+++ b/index.js
@@ -14,14 +14,14 @@ var Stream = require('stream').Stream
 
 module.exports = function (mapper, opts) {
 
-  var stream = new Stream()
-    , inputs = 0
-    , outputs = 0
-    , ended = false
-    , paused = false
-    , destroyed = false
-    , lastWritten = 0
-    , inNext = false
+  var stream = new Stream(),
+    inputs = 0,
+    outputs = 0,
+    ended = false,
+    paused = false,
+    destroyed = false,
+    lastWritten = 0,
+    inNext = false
 
   opts = opts || {};
   var errorEventName = opts.failures ? 'failure' : 'error';
@@ -33,37 +33,47 @@ module.exports = function (mapper, opts) {
   stream.writable = true
   stream.readable = true
 
-  function queueData (data, number) {
+  function queueData(data, number) {
     var nextToWrite = lastWritten + 1
+    var dataWritten = false;
 
-    if (number === nextToWrite) {
-      // If it's next, and its not undefined write it
-      if (data !== undefined) {
-        stream.emit.apply(stream, ['data', data])
-      }
-      lastWritten ++
-      nextToWrite ++
-    } else {
+    if (number !== nextToWrite) {
       // Otherwise queue it for later.
       writeQueue[number] = data
+    } else {
+      // If the next value is in the queue, write it
+      while ((number === nextToWrite && !dataWritten) || writeQueue.hasOwnProperty(nextToWrite)) {
+        // If it's next, and its not undefined write it
+        var dataToWrite;
+        if (!dataWritten) {
+          dataToWrite = data
+        } else {
+          dataToWrite = writeQueue[nextToWrite]
+          delete writeQueue[nextToWrite]
+        }
+        if (dataToWrite !== undefined) {
+          stream.emit.apply(stream, ['data', dataToWrite])
+        }
+
+        // current data is written, mark it to only write additional items in queue
+        dataWritten = true
+        lastWritten++
+        nextToWrite++
+        number++
+        outputs++
+
+        
+      }
     }
 
-    // If the next value is in the queue, write it
-    if (writeQueue.hasOwnProperty(nextToWrite)) {
-      var dataToWrite = writeQueue[nextToWrite]
-      delete writeQueue[nextToWrite]
-      return queueData(dataToWrite, nextToWrite)
-    }
-
-    outputs ++
-    if(inputs === outputs) {
-      if(paused) paused = false, stream.emit('drain') //written all the incoming events
-      if(ended) end()
+    if (inputs === outputs) {
+      if (paused) paused = false, stream.emit('drain') //written all the incoming events
+      if (ended) end()
     }
   }
 
-  function next (err, data, number) {
-    if(destroyed) return
+  function next(err, data, number) {
+    if (destroyed) return
     inNext = true
 
     if (!err || opts.failures) {
@@ -71,7 +81,7 @@ module.exports = function (mapper, opts) {
     }
 
     if (err) {
-      stream.emit.apply(stream, [ errorEventName, err ]);
+      stream.emit.apply(stream, [errorEventName, err]);
     }
 
     inNext = false;
@@ -79,16 +89,16 @@ module.exports = function (mapper, opts) {
 
   // Wrap the mapper function by calling its callback with the order number of
   // the item in the stream.
-  function wrappedMapper (input, number, callback) {
-    return mapper.call(null, input, function(err, data){
+  function wrappedMapper(input, number, callback) {
+    return mapper.call(null, input, function (err, data) {
       callback(err, data, number)
     })
   }
 
   stream.write = function (data) {
-    if(ended) throw new Error('map stream is not writable')
+    if (ended) throw new Error('map stream is not writable')
     inNext = false
-    inputs ++
+    inputs++
 
     try {
       //catch sync errors and handle them like async errors
@@ -98,26 +108,26 @@ module.exports = function (mapper, opts) {
     } catch (err) {
       //if the callback has been called syncronously, and the error
       //has occured in an listener, throw it again.
-      if(inNext)
+      if (inNext)
         throw err
       next(err)
       return !paused
     }
   }
 
-  function end (data) {
+  function end(data) {
     //if end was called with args, write it, 
     ended = true //write will emit 'end' if ended is true
     stream.writable = false
-    if(data !== undefined) {
+    if (data !== undefined) {
       return queueData(data, inputs)
     } else if (inputs == outputs) { //wait for processing 
-      stream.readable = false, stream.emit('end'), stream.destroy() 
+      stream.readable = false, stream.emit('end'), stream.destroy()
     }
   }
 
   stream.end = function (data) {
-    if(ended) return
+    if (ended) return
     end(data)
   }
 
@@ -138,7 +148,3 @@ module.exports = function (mapper, opts) {
 
   return stream
 }
-
-
-
-


### PR DESCRIPTION
This is a fix for #26 which seems to occur when too much data is queued up at once and then return using the recursive call.  We saw the error coming up when reading files with millions of lines and when pulling thousands of results from a DB.  I updated the code to follow the same logic as before, but use a loop instead to avoid recursion issues.  

I read through another thread and saw this was discussed as a potential solution, the update passed all unit testing and worked well when I tested against a few additional stream examples.  Let me know your thoughts.